### PR TITLE
@AuthenticationPrincipal LoginUser 정보 가져오기 수정

### DIFF
--- a/src/main/java/com/encore/byebuying/config/SecurityConfig.java
+++ b/src/main/java/com/encore/byebuying/config/SecurityConfig.java
@@ -94,6 +94,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .hasAnyAuthority("ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER_ADMIN");
         http.authorizeRequests().antMatchers(GET, "/api/users")
                 .hasAnyAuthority("ROLE_ADMIN", "ROLE_SUPER_ADMIN");
+        http.authorizeRequests().antMatchers(POST, "/api/users")
+                .permitAll();
         http.authorizeRequests().antMatchers(PUT, "/inquiry/answer")
                 .hasAnyAuthority("ROLE_ADMIN", "ROLE_SUPER_ADMIN");
         http.authorizeRequests().antMatchers(POST, "/message/send")

--- a/src/main/java/com/encore/byebuying/config/auth/LoginUser.java
+++ b/src/main/java/com/encore/byebuying/config/auth/LoginUser.java
@@ -1,23 +1,17 @@
 package com.encore.byebuying.config.auth;
 
 import com.encore.byebuying.domain.code.RoleType;
-import com.encore.byebuying.domain.user.dto.UserLoginInfoDTO;
 import lombok.Getter;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-
-import java.util.Collections;
+import lombok.ToString;
 
 @Getter
-public class LoginUser extends User {
-    private Long userId;
+@ToString
+public class LoginUser {
     private String username;
     private RoleType roleType;
 
-    public LoginUser(com.encore.byebuying.domain.user.User user) {
-        super(user.getUsername(), user.getPassword(), Collections.singletonList(new SimpleGrantedAuthority(user.getRoleType().getCode())));
-        this.userId = user.getId();
-        this.username = user.getUsername();
-        this.roleType = user.getRoleType();
+    public LoginUser(String username, RoleType roleType) {
+        this.username = username;
+        this.roleType = roleType;
     }
 }

--- a/src/main/java/com/encore/byebuying/config/auth/PrincipalUserDetailsService.java
+++ b/src/main/java/com/encore/byebuying/config/auth/PrincipalUserDetailsService.java
@@ -21,6 +21,6 @@ public class PrincipalUserDetailsService implements UserDetailsService {
             new UsernameNotFoundException("User not found in the database")
         );
         log.info("User found in the database: {}", username);
-        return new LoginUser(user);
+        return PrincipalDetails.create(user);
     }
 }

--- a/src/main/java/com/encore/byebuying/domain/order/controller/OrderController.java
+++ b/src/main/java/com/encore/byebuying/domain/order/controller/OrderController.java
@@ -34,8 +34,8 @@ public class OrderController {
 
 	@GetMapping("/test")
 	public String securityTest(@AuthenticationPrincipal LoginUser user) {
-		log.info("test :: LoginUser :: {}", user.getRoleType());
-		return user.getUsername();
+		log.info("test :: LoginUser :: {}", user);
+		return user.toString();
 	}
 
 	@GetMapping("")

--- a/src/main/java/com/encore/byebuying/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/com/encore/byebuying/filter/CustomAuthorizationFilter.java
@@ -4,9 +4,12 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.encore.byebuying.config.auth.LoginUser;
+import com.encore.byebuying.domain.code.RoleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -16,12 +19,14 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
-import static java.util.Arrays.stream;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpStatus.FORBIDDEN; // 403 Error
-import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE; // APPLICATION_JSON_VALUE = "application/json"
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
 
 @Slf4j
 public class CustomAuthorizationFilter extends OncePerRequestFilter {
@@ -46,7 +51,7 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
 
                     String username = decodedJWT.getSubject();
 //                    String[] roles = decodedJWT.getClaim("roles").asArray(String.class);
-                    String roles = decodedJWT.getClaim("roles").as(String.class);
+                    String roles = decodedJWT.getClaim("role").as(String.class);
 
                     Collection<SimpleGrantedAuthority> authorities = new ArrayList<>();
 
@@ -55,11 +60,13 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
 //                    });
                     authorities.add(new SimpleGrantedAuthority(roles));
                     UsernamePasswordAuthenticationToken authenticationToken =
-                            new UsernamePasswordAuthenticationToken(username, null, authorities);
+                            new UsernamePasswordAuthenticationToken(new LoginUser(username, RoleType.of(roles)), null, authorities);
                     // 유효성 검증 성공 시 SecurityContextHolder에 해당 Authentication을 잡아준다.
                     SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
                     filterChain.doFilter(request, response);
                 }catch (Exception exception) {
+                    exception.printStackTrace();
                     log.error("Error logging in: {}", exception.getMessage());
                     response.setHeader("error", exception.getMessage());
                     response.setStatus(FORBIDDEN.value());

--- a/src/test/java/com/encore/byebuying/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/encore/byebuying/domain/order/controller/OrderControllerTest.java
@@ -2,6 +2,7 @@ package com.encore.byebuying.domain.order.controller;
 
 import com.encore.byebuying.config.SecurityConfig;
 import com.encore.byebuying.config.auth.LoginUser;
+import com.encore.byebuying.config.auth.PrincipalDetails;
 import com.encore.byebuying.config.auth.PrincipalUserDetailsService;
 import com.encore.byebuying.config.oauth.PrincipalOAuth2UserService;
 import com.encore.byebuying.config.properties.AppProperties;
@@ -53,7 +54,7 @@ class OrderControllerTest {
     @MockBean
     private AppProperties appProperties;
     private MockMvc mockMvc;
-    private LoginUser loginUser;
+    private PrincipalDetails loginUser;
     private final TestPrincipalDetailsService testPrincipalDetailsService = new TestPrincipalDetailsService();
 
     @BeforeEach
@@ -62,7 +63,7 @@ class OrderControllerTest {
                 .webAppContextSetup(context)
                 .apply(springSecurity())
                 .build();
-        loginUser = (LoginUser) testPrincipalDetailsService.loadUserByUsername(TestPrincipalDetailsService.USERNAME);
+        loginUser = (PrincipalDetails) testPrincipalDetailsService.loadUserByUsername(TestPrincipalDetailsService.USERNAME);
     }
 
     @Test
@@ -85,7 +86,7 @@ class OrderControllerTest {
         @Override
         public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
             if (USERNAME.equals(username)) {
-                return new LoginUser(getUser());
+                return PrincipalDetails.create(getUser());
             }
             return null;
         }


### PR DESCRIPTION
LoginUser - username, roleType 만 보이게 수정
 - UserDetails 상속하여 만들 이유가 없음
 -  JWT token 사용 시 매 요청마다 필터에서 Authentication 생성 해당 Authentication 안 principal 을 원하는 객체로 생성해 준다.
 - 보여주고 싶은 정보만 담아서 AuthenticationToken 에 담으면 된다